### PR TITLE
Split Debian & Ubuntu repos, install instructions autodetect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 # Kanidm PPA
 
-This pulls the packages from [the Kanidm debs releases](https://github.com/kanidm/kanidm/releases/tag/debs) and makes a package archive for "nightly" packages.
+This pulls the packages from [the Kanidm debs releases](https://github.com/kanidm/kanidm/releases/tag/debs) and makes a package archive for "nightly" packages. Packages are distributed for the latest LTS versions, Ubuntu 22.04 & Debian 12.
 
 ## Adding it to your system
 
 The below commands:
 
-1. Makes sure you have a "trusted GPG" directory.
-2. Downloads the Kanidm PPA GPG public key.
-3. Adds the Kanidm PPA to your local APT configuration.
-4. Updates your local package cache.
+1. Sets pipefail so that failures are caught.
+2. Makes sure you have a "trusted GPG" directory.
+3. Downloads the Kanidm PPA GPG public key.
+4. Adds the Kanidm PPA to your local APT configuration, with autodetection of Ubuntu vs. Debian.
+5. Updates your local package cache.
 
 ``` shell
+set -o pipefail
 sudo mkdir -p /etc/apt/trusted.gpg.d/
 curl -s --compressed "https://kanidm.github.io/kanidm_ppa/KEY.gpg" \
     | gpg --dearmor \
     | sudo tee /etc/apt/trusted.gpg.d/kanidm_ppa.gpg >/dev/null
 
-sudo curl -s --compressed -o /etc/apt/sources.list.d/kanidm_ppa.list \
-    "https://kanidm.github.io/kanidm_ppa/kanidm_ppa.list"
+sudo curl -s --compressed "https://kanidm.github.io/kanidm_ppa/kanidm_ppa.list" \
+    | grep $( ( . /etc/os-release && echo $ID) ) \
+    | sudo tee /etc/apt/sources.list.d/kanidm_ppa.list
 sudo apt update
 ```
 

--- a/download.sh
+++ b/download.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-echo "Downloading $1"
+set -u
+
+echo "Downloading from $1"
 
 FILENAME="$(basename "$1")"
 
 if [ -f "$FILENAME" ]; then
     echo "File $FILENAME already exists!"
 else
-    echo "Downloading $FILENAME"
-    curl -qLf -O "$1"
+    echo -n "Downloading to $FILENAME ... "
+    curl -qsLf -O "$1" || exit 1
 fi
 
 

--- a/kanidm_ppa.list
+++ b/kanidm_ppa.list
@@ -1,1 +1,3 @@
+# Choose one of the below. The documented install oneliners grep for the correct one.
 deb [signed-by=/etc/apt/trusted.gpg.d/kanidm_ppa.gpg] https://kanidm.github.io/kanidm_ppa/ubuntu ./
+deb [signed-by=/etc/apt/trusted.gpg.d/kanidm_ppa.gpg] https://kanidm.github.io/kanidm_ppa/debian ./


### PR DESCRIPTION
Functionality can be tested by running `REPO=jinnatar/kanidm ./update.sh` as the official repo has a broken release until https://github.com/kanidm/kanidm/pull/2406 is merged.

Also misc improvements to the scripts in support of running dev testing.